### PR TITLE
Clean up handling of immediate update of new cluster

### DIFF
--- a/src/main/java/com/scaleunlimited/flinkkmeans/Cluster.java
+++ b/src/main/java/com/scaleunlimited/flinkkmeans/Cluster.java
@@ -34,12 +34,16 @@ public class Cluster implements Serializable {
         this.id = id;
     }
 
+    public boolean isUnused() {
+        return numFeatures == 0;
+    }
+
     public double distance(Feature f) {
-        if (numFeatures <= 0) {
-            return UNUSED_DISTANCE;
-        } else {
-            return centroid.distance(f, numFeatures);
+        if (numFeatures == 0) {
+            return Cluster.UNUSED_DISTANCE;
         }
+
+        return centroid.distance(f, numFeatures);
     }
     
     public void addFeature(Feature f) {
@@ -60,5 +64,6 @@ public class Cluster implements Serializable {
     public String toString() {
         return String.format("Cluster %d (%s) with %d features", id, centroid.toString(), numFeatures);
     }
+
     
 }

--- a/src/main/java/com/scaleunlimited/flinkkmeans/ClusterUpdate.java
+++ b/src/main/java/com/scaleunlimited/flinkkmeans/ClusterUpdate.java
@@ -8,15 +8,21 @@ public class ClusterUpdate implements Serializable {
     private Feature _feature;
     private int _fromClusterId;
     private int _toClusterId;
+    private boolean _newCluster;
     
     public ClusterUpdate() {
         // So it's a POJO
     }
     
     public ClusterUpdate(Feature feature, int fromClusterId, int toClusterId) {
+        this(feature, fromClusterId, toClusterId, false);
+    }
+
+    public ClusterUpdate(Feature feature, int fromClusterId, int toClusterId, boolean newCluster) {
         _feature = new Feature(feature);
         _fromClusterId = fromClusterId;
         _toClusterId = toClusterId;
+        _newCluster = newCluster;
     }
 
     public Feature getFeature() {
@@ -41,6 +47,14 @@ public class ClusterUpdate implements Serializable {
 
     public void setToClusterId(int toClusterId) {
         _toClusterId = toClusterId;
+    }
+    
+    public boolean isNewCluster() {
+        return _newCluster;
+    }
+    
+    public void setNewCluster(boolean newCluster) {
+        _newCluster = newCluster;
     }
     
     @Override

--- a/src/test/java/com/scaleunlimited/flinkkmeans/ClusterTest.java
+++ b/src/test/java/com/scaleunlimited/flinkkmeans/ClusterTest.java
@@ -17,7 +17,9 @@ public class ClusterTest {
         
         assertEquals(Cluster.UNUSED_DISTANCE, c.distance(f3), 0.01);
         c.removeFeature(f1);
-        assertEquals(Cluster.UNUSED_DISTANCE, c.distance(f3), 0.01);
+        
+        double expectedDistance = Math.sqrt(Math.pow(6-3, 2) + Math.pow(6-5, 2));
+        assertEquals(expectedDistance, c.distance(f3), 0.01);
         
         c.addFeature(f2);
         assertEquals(Cluster.UNUSED_DISTANCE, c.distance(f3), 0.01);
@@ -27,6 +29,31 @@ public class ClusterTest {
         
         c.removeFeature(f2);
         assertEquals(Cluster.UNUSED_DISTANCE, c.distance(f3), 0.01);
+    }
+    
+    @Test
+    public void testDistanceCalc() {
+        final int clusterId = 23;
+        Cluster c = new Cluster(clusterId);
+
+        final Feature f1 = new Feature(1, 1.0, 1.0);
+        assertEquals(Cluster.UNUSED_DISTANCE, c.distance(f1), 0.01);
+        
+        c.addFeature(f1);
+        assertEquals(0.0, c.distance(f1), 0.1);
+        
+        final Feature f2 = new Feature(2, 1.0, 1.0);
+        c.addFeature(f2);
+        assertEquals(0.0, c.distance(f2), 0.1);
+
+        c.removeFeature(f2);
+        assertEquals(0.0, c.distance(f1), 0.1);
+
+        c.addFeature(f2);
+        
+        final Feature f3 = new Feature(3, 4.0, 8.0);
+        double distance = Math.sqrt(Math.pow(4.0 - 1.0, 2.0) + Math.pow(8.0 - 1.0, 2.0));
+        assertEquals(distance, c.distance(f3), 0.1);
     }
 
 }

--- a/src/test/java/com/scaleunlimited/flinkkmeans/KMeansClusteringTest.java
+++ b/src/test/java/com/scaleunlimited/flinkkmeans/KMeansClusteringTest.java
@@ -179,8 +179,8 @@ public class KMeansClusteringTest {
         // Move the point towards the best cluster's location (centroid)
         double centroidX = bestCluster.getCentroid().getX();
         double centroidY = bestCluster.getCentroid().getY();
-        double newX = centroidX + (value.getX() - centroidX) * 0.8;
-        double newY = centroidY + (value.getY() - centroidY) * 0.8;
+        double newX = centroidX + (value.getX() - centroidX) * 0.5;
+        double newY = centroidY + (value.getY() - centroidY) * 0.5;
         return new Feature(value.getId(), newX, newY, -1);
     }
 


### PR DESCRIPTION
The actual attempt to defer processing of features to where we handle cluster updates couldn't possibly work (doh) because those are broadcast, so we get multiple features being emitted. But this did expose some cleanup work that was needed.