### PR TITLE
Make queryable state optional for the tool

### DIFF
--- a/src/test/java/com/scaleunlimited/flinkkmeans/KMeansClusteringTest.java
+++ b/src/test/java/com/scaleunlimited/flinkkmeans/KMeansClusteringTest.java
@@ -239,7 +239,7 @@ public class KMeansClusteringTest {
                     Cluster c = response.value();
                     System.out.println(c);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    fail("Exception getting queryable state: " + e.getMessage());
                 }
             });
         }


### PR DESCRIPTION
This means that you now have to specify `-queryable` as an option when running the tool, to get queryable state.